### PR TITLE
Generate cluster name from branch in main-vs-branch by default

### DIFF
--- a/main/main-vs-branch.yaml
+++ b/main/main-vs-branch.yaml
@@ -18,9 +18,9 @@ clusters:
   - name: main-cluster
     replicas: 3
     image: pivotalrabbitmq/rabbitmq:main-otp27
-  - name: ra-pr475-single
+  - name: #@ branch + "-single"
     replicas: 1
     image: #@ "pivotalrabbitmq/rabbitmq:" + branch + "-otp27"
-  - name: ra-pr475-cluster
+  - name: #@ branch + "-cluster"
     replicas: 3
     image: #@ "pivotalrabbitmq/rabbitmq:" + branch + "-otp27"


### PR DESCRIPTION
With this change, setting branch to the right name not only sets image tag but cluster name too. Looks like a reasonable default.